### PR TITLE
chore: remove sed suffix while generating firefox manifest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: "Chrome Artifacts"
-          path: ./Package.zip
+          path: ./dist
           if-no-files-found: error
 
       - name: Create firefox build
@@ -77,5 +77,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: "Firefox Artifacts"
-          path: ./Package.zip
+          path: ./dist
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: "Chrome Artifacts"
-          path: ./Package.zip
+          path: ./dist
           if-no-files-found: error
 
       - name: Create firefox build
@@ -59,5 +59,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: "Firefox Artifacts"
-          path: ./Package.zip
+          path: ./dist
           if-no-files-found: error

--- a/firefoxfy.sh
+++ b/firefoxfy.sh
@@ -11,4 +11,4 @@ fi
 # Replaces the content scripts for the bundled ones.
 ##
 npx rollup --config rollup.firefox.config.js --environment production
-sed -iE 's/assets\/foreground\(-[a-z]\{1,\}\)-[a-z0-9]\{1,\}.js/foreground\1.js/g' $manifest
+sed -i 's/assets\/foreground\(-[a-z]\{1,\}\)-[a-z0-9]\{1,\}.js/foreground\1.js/g' $manifest


### PR DESCRIPTION
This should help Firefox to load the CI build asset from disk. 