### PR TITLE
fix: auto enable preferences on firefox

### DIFF
--- a/firefoxfy.sh
+++ b/firefoxfy.sh
@@ -2,9 +2,14 @@
 
 dist=dist
 manifest=$dist/manifest.json
+background_wrapper=$dist/background.esm\-wrapper.js
 
 if [ ! -e "$manifest" ]; then
     echo "Could not target 'manifest.json'"
+    exit 1;
+fi
+if [ ! -e "$background_wrapper" ]; then
+    echo "Could not target 'background.esm-wrapper.js'"
     exit 1;
 fi
 ##
@@ -12,3 +17,7 @@ fi
 ##
 npx rollup --config rollup.firefox.config.js --environment production
 sed -i 's/assets\/foreground\(-[a-z]\{1,\}\)-[a-z0-9]\{1,\}.js/foreground\1.js/g' $manifest
+##
+# Replaces the chrome with browser so the onInstalled works.
+##
+sed -i 's/chrome/browser/' $background_wrapper

--- a/rollup.firefox.config.js
+++ b/rollup.firefox.config.js
@@ -52,7 +52,6 @@ function createConfig(filename, useSvelte = false) {
 
 export default [
     createConfig("components/options", true),
-    createConfig("background"),
     createConfig("foreground-common"),
     createConfig("foreground-vimeo"),
     createConfig("foreground-youtube"),


### PR DESCRIPTION
Fixes the issue the preferences are not automatically enabled on firefox browsers after install. Replaces the build `chrome` with `browser` in the background esmwrapper. 

Source: https://github.com/extend-chrome/rollup-plugin-chrome-extension/commit/e62c90bff407f7126a25109e365b74b4ee486e59#diff-bb1891dfebce9dc2adb7204823d0cd2a8845d9ff5be070977f34e55e4817340aR5